### PR TITLE
executable build/Sample is expected to be named build/sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,5 @@ endif()
 INCLUDE_DIRECTORIES("external/graph/include")
 set (CMAKE_CXX_STANDARD 11)
 
-add_executable( Sample src/cabbage.cpp )
-target_link_libraries( Sample ${OpenCV_LIBS} )
+add_executable( sample src/cabbage.cpp )
+target_link_libraries( sample ${OpenCV_LIBS} )

--- a/build_settings.py
+++ b/build_settings.py
@@ -12,5 +12,5 @@ graph_solver = join(current_loc, 'build/sample')
 with open('settings.txt', 'w') as f:
     f.write("{\n")
     f.write('\t"data_root": "/tmp/mpt",\n')
-    f.write('\t"deepmatching":"' + deepmatch + '",\n')
+    f.write('\t"deepmatch":"' + deepmatch + '",\n')
     f.write('\t"graph_solver":"' + graph_solver + '"\n}')

--- a/cabbage/MultiplePeopleTracking.py
+++ b/cabbage/MultiplePeopleTracking.py
@@ -51,7 +51,7 @@ def execute_multiple_people_tracking(video_folder, X, Dt, video_name, dmax, sett
     dm = DeepMatching(deep_matching_binary, data_root, dmax)
     dm.generate_matches(video_folder, video_name)
 
-    reid = StackNet64x64(root)
+    reid = StackNet64x64(data_root)
 
     gg = BatchGraphGenerator(data_root, reid, dm, dmax, video_name)
     gg.build(Dt, X, W, batch_size=batch_size)

--- a/cabbage/features/combined.py
+++ b/cabbage/features/combined.py
@@ -107,7 +107,7 @@ def gen_feature_batch(batch, lookup, dmax, dm, reid, W, video_name):
 
     aabb_j, aabb_i = aabb_j[IN_RANGE], aabb_i[IN_RANGE]
     scores_i, scores_j = scores_i[IN_RANGE], scores_j[IN_RANGE]
-    frame_i, framej = frame_i[IN_RANGE], frame_j[IN_RANGE]
+    frame_i, frame_j = frame_i[IN_RANGE], frame_j[IN_RANGE]
     i = i[IN_RANGE]; j = j[IN_RANGE]
 
     Im_j, Im_i = \


### PR DESCRIPTION
On case sensitive file systems would call to the `graph_solver` executable fail. This pull request fixes the name of the executable to lower case `sample`.