### PR TITLE
fix deepmatching.py(73)get_match(): assert and stacknet loading

### DIFF
--- a/cabbage/MultiplePeopleTracking.py
+++ b/cabbage/MultiplePeopleTracking.py
@@ -51,7 +51,7 @@ def execute_multiple_people_tracking(video_folder, X, Dt, video_name, dmax, sett
     dm = DeepMatching(deep_matching_binary, data_root, dmax)
     dm.generate_matches(video_folder, video_name)
 
-    reid = StackNet64x64(root)
+    reid = StackNet64x64(data_root)
 
     gg = BatchGraphGenerator(data_root, reid, dm, dmax, video_name)
     gg.build(Dt, X, W, batch_size=batch_size)

--- a/cabbage/features/combined.py
+++ b/cabbage/features/combined.py
@@ -107,7 +107,7 @@ def gen_feature_batch(batch, lookup, dmax, dm, reid, W, video_name):
 
     aabb_j, aabb_i = aabb_j[IN_RANGE], aabb_i[IN_RANGE]
     scores_i, scores_j = scores_i[IN_RANGE], scores_j[IN_RANGE]
-    frame_i, framej = frame_i[IN_RANGE], frame_j[IN_RANGE]
+    frame_i, frame_j = frame_i[IN_RANGE], frame_j[IN_RANGE]
     i = i[IN_RANGE]; j = j[IN_RANGE]
 
     Im_j, Im_i = \


### PR DESCRIPTION
Fix two typos that cause batch generation to fail on assertion and stacknet fail to load.